### PR TITLE
Handle patient deletion unreachable error

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -7,6 +7,16 @@ export function middleware(request: NextRequest) {
 
 	const { pathname } = request.nextUrl;
 
+	// If it's a Server Action submission, do NOT rewrite. Server Actions carry these headers.
+	const isServerAction =
+		request.headers.has('next-action') ||
+		request.headers.has('next-router-state-tree') ||
+		request.headers.get('content-type')?.includes('multipart/form-data') === true;
+
+	if (isServerAction) {
+		return NextResponse.next();
+	}
+
 	// /pacientes/new -> /api/pacientes/new
 	if (pathname === '/pacientes/new') {
 		const url = new URL('/api/pacientes/new', request.url);

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,12 +6,7 @@ const nextConfig = {
   // Configurar para renderização dinâmica
   experimental: {
     serverActions: {
-      allowedOrigins: [
-        'localhost:3000',
-        '127.0.0.1:3000',
-        process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : '',
-        process.env.APP_URL || '',
-      ].filter(Boolean),
+      // Remove allowedOrigins to default to same-origin submissions
     },
   },
   // Configurações para evitar problemas de export


### PR DESCRIPTION
Fix patient deletion errors by preventing middleware rewrites for Server Actions and enforcing same-origin submissions.

The original error indicated an unreachable address or failed fetch for POST requests related to patient deletion. This was due to the `middleware.ts` incorrectly rewriting Server Action POST requests and `next.config.mjs` having `allowedOrigins` configured, which could lead to cross-origin issues. The changes ensure Server Actions are handled as same-origin submissions and are not interfered with by the middleware's rewrite logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-813e2eb7-1e56-4d15-8598-1e698c0d18cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-813e2eb7-1e56-4d15-8598-1e698c0d18cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

