### PR TITLE
Corrigir edição e exclusão de máquinas

### DIFF
--- a/src/app/(app)/maquinas/[id]/edit/page.tsx
+++ b/src/app/(app)/maquinas/[id]/edit/page.tsx
@@ -3,10 +3,11 @@ import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase-server';
 import { getCurrentClinicId } from '@/lib/get-clinic';
 import { updateMaquina } from '../../_actions';
+import { ToastContainer } from '@/components/ui/Toast';
 
 export const dynamic = 'force-dynamic';
 
-export default async function EditarMaquinaPage({ params }: { params: { id: string } }) {
+export default async function EditarMaquinaPage({ params, searchParams }: { params: { id: string }; searchParams?: { ok?: string; error?: string } }) {
   const supabase = createClient();
   const clinica_id = await getCurrentClinicId();
 
@@ -41,6 +42,10 @@ export default async function EditarMaquinaPage({ params }: { params: { id: stri
 
   return (
     <div className="p-6 space-y-6">
+      <ToastContainer 
+        successMessage={searchParams?.ok ? decodeURIComponent(searchParams.ok) : undefined}
+        errorMessage={searchParams?.error ? decodeURIComponent(searchParams.error) : undefined}
+      />
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold">Editar Máquina</h1>
         <Link

--- a/supabase/migrations/006_fix_maquinas_timestamps.sql
+++ b/supabase/migrations/006_fix_maquinas_timestamps.sql
@@ -1,0 +1,41 @@
+-- 006_fix_maquinas_timestamps.sql
+-- Garantir colunas de timestamp em maquinas e trigger de updated_at
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_name='maquinas' AND column_name='created_at'
+  ) THEN
+    ALTER TABLE maquinas ADD COLUMN created_at TIMESTAMPTZ DEFAULT NOW();
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns 
+    WHERE table_name='maquinas' AND column_name='updated_at'
+  ) THEN
+    ALTER TABLE maquinas ADD COLUMN updated_at TIMESTAMPTZ DEFAULT NOW();
+  END IF;
+END $$;
+
+-- Função genérica para atualizar updated_at, reutiliza se já existir
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Criar trigger apenas se ainda não existir
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger 
+    WHERE tgname = 'update_maquinas_updated_at'
+  ) THEN
+    CREATE TRIGGER update_maquinas_updated_at
+    BEFORE UPDATE ON maquinas
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+  END IF;
+END $$;


### PR DESCRIPTION
Fix `maquinas` table `updated_at` column missing error by adding timestamps and a trigger, and provide UI feedback for edit operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-20e8f849-0fa9-433f-b297-e8a7c2378d21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-20e8f849-0fa9-433f-b297-e8a7c2378d21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

