### PR TITLE
Fix updated_at column error in maquinas module

### DIFF
--- a/src/services/maquinas.ts
+++ b/src/services/maquinas.ts
@@ -101,8 +101,7 @@ export class MaquinasService {
       const { data, error } = await this.supabase
         .from('maquinas')
         .update({
-          ...maquina,
-          updated_at: new Date().toISOString()
+          ...maquina
         })
         .eq('id', id)
         .eq('clinica_id', clinicaId)
@@ -121,8 +120,7 @@ export class MaquinasService {
       const { data, error } = await this.supabase
         .from('maquinas')
         .update({
-          ativa,
-          updated_at: new Date().toISOString()
+          ativa
         })
         .eq('id', id)
         .eq('clinica_id', clinicaId)


### PR DESCRIPTION
Remove manual `updated_at` assignment from `maquinas` service updates to prevent schema cache errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a8c4cc1-316d-4a7b-bf4b-a14fe2be51fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8a8c4cc1-316d-4a7b-bf4b-a14fe2be51fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

