### PR TITLE
Fix heparina tabela pacientes type error

### DIFF
--- a/src/components/heparina/HeparinaTabelaPacientes.tsx
+++ b/src/components/heparina/HeparinaTabelaPacientes.tsx
@@ -189,10 +189,10 @@ export default function HeparinaTabelaPacientes({ pacientes, onDoseUpdate }: Pro
                           {paciente.cidade}
                         </Badge>
                       )}
-                      {paciente.sessao_atual && (
+                      {paciente.sessao_atual?.data_sessao && (
                         <Badge variant="neutral" className="text-xs">
                           <Clock className="h-3 w-3 mr-1" />
-                          {paciente.sessao_atual?.turno ? formatarTurno(paciente.sessao_atual.turno as string) : ''}
+                          {new Date(paciente.sessao_atual.data_sessao).toLocaleDateString('pt-BR')}
                         </Badge>
                       )}
                       {paciente.acesso_vascular?.tipo && (


### PR DESCRIPTION
Fixes a build-time type error by replacing the non-existent `turno` property with the session date in `HeparinaTabelaPacientes.tsx`.

The `sessoes_hemodialise.Row` type, which `paciente.sessao_atual` adheres to, does not include a `turno` field. Attempting to access `paciente.sessao_atual.turno` resulted in a TypeScript compilation error. This PR updates the component to display the `data_sessao` instead, which is a valid property.

---
<a href="https://cursor.com/background-agent?bcId=bc-04b12606-13d5-4cb2-a80e-f00095435f97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-04b12606-13d5-4cb2-a80e-f00095435f97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

