### PR TITLE
Fix patient form label for attribute error

### DIFF
--- a/src/app/(app)/pacientes/_form.tsx
+++ b/src/app/(app)/pacientes/_form.tsx
@@ -194,7 +194,7 @@ export default function PacienteForm({
                 onChange={(value) => setFormData(prev => ({ ...prev, sexo: value }))}
                 error={errors.sexo}
               />
-              <input type="hidden" name="sexo" value={formData.sexo} />
+              <input type="hidden" id="sexo" name="sexo" value={formData.sexo} />
             </div>
 
             {/* Telefone */}
@@ -250,7 +250,7 @@ export default function PacienteForm({
                 onChange={(value) => setFormData(prev => ({ ...prev, convenio: value }))}
                 error={errors.convenio}
               />
-              <input type="hidden" name="convenio" value={formData.convenio} />
+              <input type="hidden" id="convenio" name="convenio" value={formData.convenio} />
             </div>
 
             {/* Número do Convênio */}


### PR DESCRIPTION
Resolve "Paciente não encontrado" error during edit and correct label accessibility warnings.

The patient edit page now correctly filters by `clinica_id` when fetching a patient, preventing Row Level Security (RLS) from incorrectly hiding the record. Additionally, `label` elements for 'Sexo' and 'Convênio' now correctly reference their associated hidden input fields via `id` attributes.

---
<a href="https://cursor.com/background-agent?bcId=bc-01ffc00e-beb4-4930-9681-02f05155b9b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01ffc00e-beb4-4930-9681-02f05155b9b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

